### PR TITLE
fix(cpe-tag): more verbose error when cpe match feed not found

### DIFF
--- a/crates/cpe-tag/src/query_builder.rs
+++ b/crates/cpe-tag/src/query_builder.rs
@@ -21,6 +21,10 @@ pub fn get_grep_patterns(packages: &[Package]) -> Result<String, Box<dyn Error>>
 pub fn query(pattern: String, feed: &Path) -> Result<Vec<String>, Box<dyn Error>> {
     let matcher = RegexMatcher::new_line_matcher(&pattern)?;
     let mut matches: Vec<String> = vec![];
+    if !feed.exists() {
+        log::error!("{:?} doesn't exist", feed.as_os_str());
+    }
+
     Searcher::new().search_path(
         &matcher,
         feed,


### PR DESCRIPTION
current error only states "No such file or directory (os error 2)"
it would be good that error log also mentions something about path