### PR TITLE
feat(scan): package name as report filename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,8 @@ dependencies = [
  "log",
  "once_cell",
  "os-adapter",
+ "rayon",
+ "regex",
  "reqwest",
  "security-advisories",
  "serde",
@@ -199,7 +201,7 @@ dependencies = [
  "structopt",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.7.1",
 ]
 
 [[package]]
@@ -258,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
@@ -272,6 +274,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+dependencies = [
+ "cfg-if 1.0.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -306,14 +353,20 @@ dependencies = [
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encode_unicode"
@@ -323,9 +376,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -496,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -604,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
  "bytes",
  "fnv",
@@ -617,7 +670,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.1",
  "tracing",
 ]
 
@@ -687,9 +740,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.17"
+version = "0.14.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
+checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -735,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -810,9 +863,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.56"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
+checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -840,7 +893,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
- "time 0.3.7",
+ "time 0.3.9",
  "url",
  "uuid",
 ]
@@ -853,24 +906,25 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5c14e80759d0939d013e6ca49930e59fc53dd8e5009132f76240c179380c09"
+checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
 
 [[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -897,6 +951,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba42135c6a5917b9db9cd7b293e5409e1c6b041e6f9825e92e55a894c63b6f8"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
  "log",
@@ -943,9 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
 dependencies = [
  "lazy_static",
  "libc",
@@ -961,13 +1024,12 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.0"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
- "version_check",
 ]
 
 [[package]]
@@ -1074,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "num_threads"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c539a50b93a303167eded6e8dff5220cd39447409fb659f4cd24b1f72fe4f133"
+checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
 dependencies = [
  "libc",
 ]
@@ -1152,7 +1214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.1",
+ "parking_lot_core 0.9.2",
 ]
 
 [[package]]
@@ -1171,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1221,9 +1283,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "proc-macro-error"
@@ -1257,9 +1319,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
 ]
@@ -1324,30 +1386,56 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.11"
+name = "rayon"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
  "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -1412,7 +1500,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-util",
+ "tokio-util 0.6.9",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1553,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
@@ -1605,9 +1693,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.87"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e59d925cf59d8151f25a3bedf97c9c157597c9df7324d32d68991cc399ed08b"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1657,6 +1745,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
  "libc",
  "num_threads",
@@ -1689,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tinyvec"
@@ -1774,6 +1882,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1796,14 +1918,26 @@ checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.1.23"
+name = "tracing-attributes"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
 dependencies = [
  "lazy_static",
 ]
@@ -1919,9 +2053,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
+checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -1929,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
+checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1944,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
+checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1956,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
+checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1966,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
+checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1979,15 +2113,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "web-sys"
-version = "0.3.56"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
+checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2026,9 +2160,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -2039,33 +2173,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "winreg"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,10 +23,14 @@ sha2 = "0.10.1"
 structopt = "0.3.26"
 tokio = { version = "1.15.0", features = ["fs", "io-util", "macros", "process", "rt-multi-thread"] }
 tokio-stream = "0.1.8"
-tokio-util = { version = "0.6.9", features = ["io"] }
+tokio-util = { version = "0.7.1", features = ["io"] }
 atty = "0.2.14"
 once_cell = "1.9.0"
 chrono = "0.4.19"
 reqwest = "0.11.9"
 serde = "1.0.136"
 confy = "0.4.0"
+rayon = "1.5.1"
+regex = "1.5.5"
+
+[features]

--- a/crates/cli/src/command/cpe.rs
+++ b/crates/cli/src/command/cpe.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use cpe_tag::query_builder::{get_grep_patterns, query};
+use cpe_tag::query_builder::{get_regex_pattern, query};
 use cpe_tag::validators::into_validated_packages;
 use security_advisories::service::CPE_MATCH_FEED;
 use serde_json::from_str;
@@ -18,7 +18,7 @@ pub async fn execute(batch: String, feed_dir: PathBuf) -> Result<(), Box<dyn Err
     let json = into_validated_packages(&json)?;
 
     log::info!("building query ...");
-    let pattern = get_grep_patterns(&json)?;
+    let pattern = get_regex_pattern(&json)?;
     log::info!("searching patterns in CPE match feed ...");
     let matches = query(pattern, &feed_dir.join(CPE_MATCH_FEED))?;
 

--- a/crates/cli/src/command/scan.rs
+++ b/crates/cli/src/command/scan.rs
@@ -4,21 +4,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
 use crate::conf::ApiKeys;
 use chrono::{Timelike, Utc};
 use cpe_tag::package::Package;
-use cpe_tag::query_builder::{get_grep_patterns, query};
+use cpe_tag::query_builder::{get_regex_pattern, get_value};
 use os_adapter::adapter::{get_adapter, OsAdapter};
+use rayon::prelude::*;
+use regex::Regex;
 use reqwest::Client;
 use security_advisories::cve_summary::CveSummary;
 use security_advisories::http::get_client;
 use security_advisories::service::{
     fetch_cves_by_cpe, fetch_known_exploited_cves, get_cves_summary, CPE_MATCH_FEED,
 };
+use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fs::{create_dir_all, read_dir, set_permissions, File};
-use std::io::Write;
+use std::io::{self, BufRead, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
@@ -91,20 +93,29 @@ async fn scan(
 ) -> Result<(), Box<dyn Error>> {
     log::info!("listing all catpkgs ...");
     let catpkgs = os.get_all_catpkgs()?;
+    let mut feed_buffer = HashSet::new();
+    load_feed(feed, &mut feed_buffer)?;
 
     for (ctg, pkgs) in catpkgs {
         if pkgs.is_empty() {
             continue;
         }
 
-        let cwd = out_dir.join(&ctg);
         log::debug!("processing {} ...", ctg);
+        let cwd = out_dir.join(&ctg);
+        let mut regex_buffer = vec![];
+        let mut result_buffer = vec![];
+
+        load_regex(pkgs, &mut regex_buffer)?;
+        regex_buffer
+            .par_iter()
+            .map(|(pkg, re)| match_cpes(&feed_buffer, pkg, re))
+            .collect_into_vec(&mut result_buffer);
         handle_pkgs(
             client,
-            feed,
             &cwd,
             &ctg,
-            &pkgs,
+            &result_buffer,
             known_exploited_cves,
             api_keys,
         )
@@ -113,45 +124,86 @@ async fn scan(
     Ok(())
 }
 
+fn load_feed(feed: &Path, buffer: &mut HashSet<String>) -> Result<(), Box<dyn Error>> {
+    log::debug!("loading feed into memory ...");
+    let file = File::open(feed)?;
+    let lines = io::BufReader::new(file).lines();
+    for line in lines.flatten() {
+        if line.contains("cpe23Uri") {
+            buffer.insert(get_value(&line));
+        }
+    }
+    Ok(())
+}
+
+fn load_regex(
+    pkgs: Vec<Package>,
+    buffer: &mut Vec<(Package, Regex)>,
+) -> Result<(), Box<dyn Error>> {
+    for pkg in pkgs {
+        let pattern = get_regex_pattern(&[pkg.clone()])?;
+        let re = Regex::new(pattern.as_ref())?;
+        buffer.push((pkg, re));
+    }
+    Ok(())
+}
+
+fn match_cpes<'a>(
+    feed: &'a HashSet<String>,
+    pkg: &'a Package,
+    re: &'a Regex,
+) -> HashMap<&'a Package, Vec<String>> {
+    let mut cpes = HashMap::new();
+    let matches = feed
+        .iter()
+        .filter(|feed_entry| re.is_match(feed_entry))
+        .map(|x| x.to_owned())
+        .collect();
+    cpes.insert(pkg, matches);
+    cpes
+}
+
 async fn handle_pkgs(
     client: &Client,
-    feed: &Path,
     cwd: &Path,
     category: &str,
-    pkgs: &[Package],
+    pkgs: &[HashMap<&Package, Vec<String>>],
     known_exploited_cves: &[String],
     api_keys: &ApiKeys,
 ) -> Result<(), Box<dyn Error>> {
-    let pattern = get_grep_patterns(pkgs)?;
-    let matches = query(pattern, feed)?;
+    for items in pkgs {
+        for (pkg, matches) in items {
+            let pkg_name = pkg.to_string();
 
-    if matches.is_empty() {
-        log::info!(
-            "no CPE matches in {}. This *MIGHT* indicate false negatives ...",
-            category
-        );
-        return Ok(());
+            if matches.is_empty() {
+                continue;
+            }
+
+            log::debug!(
+                "found CPE(s) for {}/{}. Searching for CVEs ...",
+                category,
+                &pkg_name
+            );
+            handle_cves(
+                client,
+                cwd,
+                category,
+                &pkg_name,
+                matches,
+                known_exploited_cves,
+                api_keys,
+            )
+            .await?;
+        }
     }
-
-    log::info!(
-        "found CPEs for packages in {}. Searching for CVEs ...",
-        category
-    );
-    handle_cves(
-        client,
-        cwd,
-        category,
-        &matches,
-        known_exploited_cves,
-        api_keys,
-    )
-    .await
+    Ok(())
 }
 
 async fn handle_cves(
     client: &Client,
     cwd: &Path,
     category: &str,
+    pkg_name: &str,
     matches: &[String],
     known_exploited_cves: &[String],
     api_keys: &ApiKeys,
@@ -171,22 +223,28 @@ async fn handle_cves(
         }
 
         if !already_notified {
-            log::warn!("found CVEs in {} ...", category);
+            log::warn!("found CVEs for {}/{} ...", category, pkg_name);
             already_notified = true;
         }
-        write_report(cwd, cpe, &cves)?;
+        write_report(cwd, pkg_name, cves, cpe)?;
     }
 
     Ok(())
 }
 
-fn write_report(cwd: &Path, cpe: &str, cves: &[CveSummary]) -> Result<(), Box<dyn Error>> {
+fn write_report(
+    cwd: &Path,
+    pkg_name: &str,
+    cves: Vec<CveSummary>,
+    cpe: &str,
+) -> Result<(), Box<dyn Error>> {
     create_dir_all(cwd)?;
-    let f = cwd.join(format!("{}.txt", cpe));
-    log::info!("saving report in {:?} ...", f.as_os_str());
+    let f = cwd.join(format!("{}.txt", pkg_name));
+    log::debug!("saving report in {:?} ...", f.as_os_str());
     let mut f = File::create(f)?;
 
-    for cve in cves {
+    for mut cve in cves {
+        cve.related_cpe = Some(cpe.to_owned());
         log::debug!("{}", cve.id);
         writeln!(f, "{}", cve)?;
     }

--- a/crates/cpe-tag/python/integrator.py
+++ b/crates/cpe-tag/python/integrator.py
@@ -20,7 +20,12 @@ def handle_list(packages: list) -> list:
 
 
 def handle_dict(package: dict) -> list:
-    serialized = serialize_package_json(package)
+    serialized = serialize_package_json(get_package_adapter(package))
     quasi_cpes = list(map(lambda x: x.get("quasi_cpe"), serialized["versions"]))
     quasi_cpes = list(filter(lambda x: x is not None, quasi_cpes))
     return [convert_quasi_cpe_to_regex(qc) for qc in quasi_cpes]
+
+
+def get_package_adapter(package: dict) -> dict:
+    versions_adapter = [{'version': package.get('version')}]
+    return {'name': package.get('name'), 'versions': versions_adapter}

--- a/crates/cpe-tag/schemas/package.schema.json
+++ b/crates/cpe-tag/schemas/package.schema.json
@@ -3,22 +3,13 @@
   "$id": "http://localhost/schemas/package",
   "title": "raw package",
   "type": "object",
-  "required": ["name", "versions"],
+  "required": ["name", "version"],
   "properties": {
     "name": {"type": "string", "description": "package name"},
     "homepages": {
       "type": "array",
       "items": {"type": "string", "description": "project homepage"}
     },
-    "versions": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["version"],
-        "properties": {
-          "version": {"type": "string", "description": "package version"}
-        }
-      }
-    }
+    "version": {"type": "string", "description": "package version"}
   }
 }

--- a/crates/cpe-tag/src/package.rs
+++ b/crates/cpe-tag/src/package.rs
@@ -7,6 +7,7 @@
 
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::string::ToString;
 
 pub fn convert_to_pkg(raw_pkg: &str) -> Option<Package> {
     let pattern = "(.+)-([0-9]+.*)";
@@ -19,32 +20,27 @@ pub fn convert_to_pkg(raw_pkg: &str) -> Option<Package> {
     if name.is_some() && version.is_some() {
         let name = name?.as_str().to_owned();
         let version = version?.as_str().to_owned();
-        Some(Package::new(name, vec![Version::new(version)]))
+        Some(Package::new(name, version))
     } else {
         None
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, Hash, PartialEq, Eq)]
 pub struct Package {
-    name: String,
-    versions: Vec<Version>,
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct Version {
-    version: String,
+    pub name: String,
+    pub version: String,
 }
 
 impl Package {
-    pub fn new(name: String, versions: Vec<Version>) -> Self {
-        Self { name, versions }
+    pub fn new(name: String, version: String) -> Self {
+        Self { name, version }
     }
 }
 
-impl Version {
-    pub fn new(version: String) -> Self {
-        Self { version }
+impl ToString for Package {
+    fn to_string(&self) -> String {
+        format!("{}-{}", self.name, self.version)
     }
 }
 
@@ -55,10 +51,14 @@ mod tests {
     #[test]
     fn it_should_convert_raw_pkg_into_struct() {
         let raw_pkg = "rust-bin-1.58.1";
-        let expected = Some(Package::new(
-            "rust-bin".to_owned(),
-            vec![Version::new("1.58.1".to_owned())],
-        ));
+        let expected = Some(Package::new("rust-bin".to_owned(), "1.58.1".to_owned()));
         assert_eq!(expected, convert_to_pkg(raw_pkg));
+    }
+
+    #[test]
+    fn it_should_implement_to_string() {
+        let expected = "rust-bin-1.58.1";
+        let package = Package::new("rust-bin".to_owned(), "1.58.1".to_owned());
+        assert_eq!(expected.to_owned(), package.to_string());
     }
 }

--- a/crates/cpe-tag/src/query_builder.rs
+++ b/crates/cpe-tag/src/query_builder.rs
@@ -14,8 +14,8 @@ use std::error::Error;
 use std::path::Path;
 mod py_query_builder;
 
-pub fn get_grep_patterns(packages: &[Package]) -> Result<String, Box<dyn Error>> {
-    py_query_builder::get_grep_patterns(packages)
+pub fn get_regex_pattern(packages: &[Package]) -> Result<String, Box<dyn Error>> {
+    py_query_builder::get_regex_pattern(packages)
 }
 
 pub fn query(pattern: String, feed: &Path) -> Result<Vec<String>, Box<dyn Error>> {
@@ -40,11 +40,15 @@ pub fn query(pattern: String, feed: &Path) -> Result<Vec<String>, Box<dyn Error>
     Ok(get_values(matches))
 }
 
+pub fn get_value(line: &str) -> String {
+    let s: Vec<&str> = line.rsplit(" : ").collect();
+    s[0].trim().trim_matches(',').trim_matches('"').to_owned()
+}
+
 fn get_values(matches: Vec<String>) -> Vec<String> {
     let mut values: Vec<String> = vec![];
     for m in matches {
-        let s: Vec<&str> = m.rsplit(" : ").collect();
-        values.push(s[0].trim().trim_matches(',').trim_matches('"').to_owned());
+        values.push(get_value(&m));
     }
     values.sort();
     values.dedup();

--- a/crates/cpe-tag/src/query_builder/py_query_builder.rs
+++ b/crates/cpe-tag/src/query_builder/py_query_builder.rs
@@ -10,7 +10,7 @@ use pyo3::prelude::*;
 use pythonize::pythonize;
 use std::error::Error;
 
-pub fn get_grep_patterns(packages: &[Package]) -> Result<String, Box<dyn Error>> {
+pub fn get_regex_pattern(packages: &[Package]) -> Result<String, Box<dyn Error>> {
     let from_python = call_python_code(packages);
     Ok(from_python?.to_string())
 }
@@ -72,23 +72,23 @@ mod tests {
     fn it_should_return_grep_patterns() {
         let test_data = [
             [
-                r#"[{"name":"busybox","versions":[{"version":"1.31.0"},{"version":"9999"}]}]"#,
+                r#"[{"name":"busybox","version":"1.31.0"},{"name":"busybox","version":"9999"}]"#,
                 r#":busybox:1\.31\.0:[\*\-]:[^:]+:[^:]+:[^:]+:(linux|\*):[^:]+:[^:]"#,
             ],
             [
-                r#"[{"name":"busybox","versions":[{"version":"1.31.0"},{"version":"1.29.3"}]}]"#,
+                r#"[{"name":"busybox","version":"1.31.0"},{"name":"busybox","version":"1.29.3"}]"#,
                 r#":busybox:1\.31\.0:[\*\-]:[^:]+:[^:]+:[^:]+:(linux|\*):[^:]+:[^:]|:busybox:1\.29\.3:[\*\-]:[^:]+:[^:]+:[^:]+:(linux|\*):[^:]+:[^:]"#,
             ],
             [
-                r#"[{"name":"libxml2","versions":[{"version":"2.9.10-r5"}]},{"name":"openssh","versions":[{"version":"8.4_p1-r3"}]}]"#,
+                r#"[{"name":"libxml2","version":"2.9.10-r5"},{"name":"openssh","version":"8.4_p1-r3"}]"#,
                 r#":libxml2:2\.9\.10:[\*\-]:[^:]+:[^:]+:[^:]+:(linux|\*):[^:]+:[^:]|:openssh:8\.4:(p1|\*):[^:]+:[^:]+:[^:]+:(linux|\*):[^:]+:[^:]"#,
             ],
             [
-                r#"[{"name":"google-chrome","versions":[{"version":"97.0.4692.71"}]}]"#,
+                r#"[{"name":"google-chrome","version":"97.0.4692.71"}]"#,
                 r#"google:chrome:97\.0\.4692\.71:[\*\-]:[^:]+:[^:]+:[^:]+:(linux|\*):[^:]+:[^:]"#,
             ],
             [
-                r#"[{"name":"nicotine+","versions":[{"version":"1.4.1-r1"}]}]"#,
+                r#"[{"name":"nicotine+","version":"1.4.1-r1"}]"#,
                 r#":nicotine\+:1\.4\.1:[\*\-]:[^:]+:[^:]+:[^:]+:(linux|\*):[^:]+:[^:]"#,
             ],
         ];
@@ -96,7 +96,7 @@ mod tests {
             let [json, expected] = d;
             let json: Value = from_str(json).unwrap();
             let json = into_validated_packages(&json).unwrap();
-            assert_eq!(get_grep_patterns(&json).unwrap(), expected.to_owned());
+            assert_eq!(get_regex_pattern(&json).unwrap(), expected.to_owned());
         }
     }
 }

--- a/crates/cpe-tag/src/validators.rs
+++ b/crates/cpe-tag/src/validators.rs
@@ -85,14 +85,13 @@ mod tests {
     use super::*;
 
     fn get_valid_packages_batch() -> Value {
-        from_str(r#"[{"name": "busybox", "versions": [{"version": "1.29.3"}]}]"#).unwrap()
+        from_str(r#"[{"name": "busybox", "version": "1.29.3"}]"#).unwrap()
     }
 
     #[test]
     fn it_should_validate_packages_batch() {
         let valid_batch = get_valid_packages_batch();
-        let invalid_batch =
-            from_str(r#"{"name": "busybox", "versions": [{"version": "1.29.3"}]}"#).unwrap();
+        let invalid_batch = from_str(r#"{"name": "busybox", "version": "1.29.3"}"#).unwrap();
         assert!(into_validated_packages(&valid_batch).is_ok());
         assert!(into_validated_packages(&invalid_batch).is_err());
     }

--- a/crates/security-advisories/src/cve_summary.rs
+++ b/crates/security-advisories/src/cve_summary.rs
@@ -13,6 +13,7 @@ use std::fmt;
 pub struct CveSummary {
     pub id: String,
     pub is_known_exploited_vuln: Option<bool>,
+    pub related_cpe: Option<String>,
     pub description: String,
     pub urls: Vec<String>,
 }
@@ -22,6 +23,7 @@ impl CveSummary {
         Self {
             id,
             is_known_exploited_vuln: None,
+            related_cpe: None,
             description,
             urls,
         }

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -26,17 +26,13 @@ Results in:
 $ tree ~/vulner/scan-results/
 ```
 ```
-└── 2022-01-30UTC
-    └── 11:10:06Z
+└── 2022-04-05UTC
+    └── 21:13:11Z
         ├── app-emulation
-        │   ├── cpe:2.3:a:linuxfoundation:containerd:1.5.5:*:*:*:*:*:*:*.txt
-        │   ├── cpe:2.3:a:linuxfoundation:runc:1.0.1:*:*:*:*:*:*:*.txt
-        │   └── cpe:2.3:a:qemu:qemu:5.2.0:-:*:*:*:*:*:*.txt
-        ├── dev-libs
-        │   ├── cpe:2.3:a:openssl:openssl:1.1.1l:*:*:*:*:*:*:*.txt
-        │   └── cpe:2.3:a:xmlsoft:libxml2:2.9.10:*:*:*:*:*:*:*.txt
+        │   ├── containerd-1.5.9.txt
+        │   └── qemu-6.2.0-r3.txt
         └── x11-terms
-            └── cpe:2.3:a:twistedmatrix:twisted:18.7.0:*:*:*:*:*:*:*.txt
+            └── xterm-346.txt
 ```
 Report for particular package:
 ```bash
@@ -46,6 +42,7 @@ $ cat ~/vulner/scan-results/2022-01-30UTC/*/app-emulation/*containerd*.txt | jq 
 {
   "id": "CVE-2021-41103",
   "is_known_exploited_vuln": false,
+  "related_cpe": "cpe:2.3:a:linuxfoundation:containerd:1.5.5:*:*:*:*:*:*:*",
   "description": "A bug was found in containerd where container root directories and some plugins had insufficiently restricted permissions, allowing otherwise unprivileged Linux users to traverse directory contents and execute programs.",
 ,
   "urls": [
@@ -87,7 +84,7 @@ vulner scan --pkg-dir /var/git/meta-repo/ --recursive
 ### Example 1
 ```bash
 vulner sync
-vulner cpe '[{"name":"lua", "versions":[{"version":"5.3.5-r1"}]}]' | vulner cve --summary
+vulner cpe '[{"name":"lua", "version":"5.3.5-r1"}]' | vulner cve --summary
 ```
 
 ### Example 2
@@ -99,22 +96,15 @@ RUST_LOG=debug vulner sync && echo '
 [
   {
     "name": "busybox",
-    "versions": [
-      {
-        "version": "1.29.3"
-      },
-      {
-        "version": "1.31.0"
-      }
-    ]
+    "version": "1.29.3"
+  },
+  {
+    "name": "busybox",
+    "version": "1.31.0"
   },
   {
     "name": "libxml2",
-    "versions": [
-      {
-        "version": "2.9.10-r5"
-      }
-    ]
+    "version": "2.9.10-r5"
   }
 ]
 ' | jq -c '.' | vulner cpe | vulner cve --summary --check-known-exploited


### PR DESCRIPTION
## issue
currently filename of scan report is derived from CPE - this creates certain inconveniences e.g. with readability

## root cause of issue
packages are grouped in one CPE feed query

## feature
query CPE feed for each package separately persisting original package name and version

## tradeoff
CPE feed is loaded into memory