### PR TITLE
fix(scan): append package report file instead of truncate

### DIFF
--- a/crates/cli/src/command/scan.rs
+++ b/crates/cli/src/command/scan.rs
@@ -19,7 +19,7 @@ use security_advisories::service::{
 };
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
-use std::fs::{create_dir_all, read_dir, set_permissions, File};
+use std::fs::{create_dir_all, read_dir, set_permissions, File, OpenOptions};
 use std::io::{self, BufRead, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -241,12 +241,13 @@ fn write_report(
     create_dir_all(cwd)?;
     let f = cwd.join(format!("{}.txt", pkg_name));
     log::debug!("saving report in {:?} ...", f.as_os_str());
-    let mut f = File::create(f)?;
 
+    let mut buffer = OpenOptions::new().create(true).append(true).open(f)?;
     for mut cve in cves {
         cve.related_cpe = Some(cpe.to_owned());
         log::debug!("{}", cve.id);
-        writeln!(f, "{}", cve)?;
+        writeln!(buffer, "{}", cve)?;
     }
+
     Ok(())
 }


### PR DESCRIPTION
## bug description
this bug was introduced in commit 4aed9073cc, causing scan report to be
overwritten if given package had more than one CPE containing CVEs

## root cause
`File::create()` truncates file if it exists
(https://doc.rust-lang.org/std/fs/struct.File.html#method.create)